### PR TITLE
Use <3.14 instead of <=3.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: b333feceb79ea190d5205735f664506b74a94241da096a7996ca5cf8ea88c280
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   noarch: python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "boinor" %}
 {% set version = "0.19.0" %}
 {% set python_min = "3.10" %}
-{% set python_max = "3.13" %}
+{% set python_max = "3.14" %}
 
 
 package:
@@ -32,7 +32,7 @@ requirements:
     - pandas
     - plotly <6,>=4.0
     - pyerfa
-    - python >={{ python_min }},<={{ python_max }}.*
+    - python >={{ python_min }},<{{ python_max }}
     - scipy >=1.4.0
     - cached-property
     - pyerfa

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ requirements:
     - pandas
     - plotly <6,>=4.0
     - pyerfa
-    - python >={{ python_min }},<={{ python_max }}
+    - python >={{ python_min }},<={{ python_max }}.*
     - scipy >=1.4.0
     - cached-property
     - pyerfa


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

The python <= 3.13 effectively excluded python 3.13 (e.g. python 3.13.7)
